### PR TITLE
[#90] 추가 근무 상태 추가 및 필터링 조회 기능 추가

### DIFF
--- a/src/main/java/com/stamp/api/extraShift/controller/ExtraShiftController.java
+++ b/src/main/java/com/stamp/api/extraShift/controller/ExtraShiftController.java
@@ -6,8 +6,10 @@ import com.stamp.api.extraShift.service.CreateExtraShiftService;
 import com.stamp.api.extraShift.service.ReadExtraShiftService;
 import com.stamp.api.extraShift.service.UpdateExtraShiftService;
 import com.stamp.global.response.ApplicationResponse;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/store/{storeId}/extraShifts")
@@ -41,6 +44,14 @@ public class ExtraShiftController {
       @AuthenticationPrincipal UserDetails userDetails) {
     return ApplicationResponse.ok(
         readExtraShiftService.getExtraShiftRequests(Long.valueOf(userDetails.getUsername())));
+  }
+
+  @GetMapping("/getRequests/{employeeId}")
+  public ApplicationResponse<ExtraShiftRes> getExtraShiftRequestsByDate(
+      @PathVariable("employeeId") Long employeeId,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+    return ApplicationResponse.ok(
+        readExtraShiftService.getExtraShiftRequestsByDate(employeeId, date));
   }
 
   @PutMapping("/{extraShiftId}/acceptRequest")

--- a/src/main/java/com/stamp/api/extraShift/entity/ExtraShift.java
+++ b/src/main/java/com/stamp/api/extraShift/entity/ExtraShift.java
@@ -27,7 +27,7 @@ public class ExtraShift {
   private LocalDate requestDate; // 추가 근무 요청 날짜
 
   @Enumerated(EnumType.STRING)
-  private RequestStatus status = RequestStatus.REQUESTED;
+  private RequestStatus status = RequestStatus.CREATED;
 
   @ManyToOne
   @JoinColumn(name = "employee_id")

--- a/src/main/java/com/stamp/api/extraShift/entity/RequestStatus.java
+++ b/src/main/java/com/stamp/api/extraShift/entity/RequestStatus.java
@@ -1,6 +1,7 @@
 package com.stamp.api.extraShift.entity;
 
 public enum RequestStatus {
+  CREATED,
   REQUESTED,
   ACCEPTED,
   REJECTED

--- a/src/main/java/com/stamp/api/extraShift/repository/ExtraShiftRepository.java
+++ b/src/main/java/com/stamp/api/extraShift/repository/ExtraShiftRepository.java
@@ -1,11 +1,15 @@
 package com.stamp.api.extraShift.repository;
 
 import com.stamp.api.extraShift.entity.ExtraShift;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ExtraShiftRepository extends JpaRepository<ExtraShift, Long> {
   List<ExtraShift> findAllByEmployeeId(Long employeeId);
+
+  Optional<ExtraShift> findByEmployeeIdAndRequestDate(Long employeeId, LocalDate requestDate);
 }

--- a/src/main/java/com/stamp/api/extraShift/service/ReadExtraShiftService.java
+++ b/src/main/java/com/stamp/api/extraShift/service/ReadExtraShiftService.java
@@ -1,8 +1,11 @@
 package com.stamp.api.extraShift.service;
 
 import com.stamp.api.extraShift.dto.response.ExtraShiftRes;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ReadExtraShiftService {
   List<ExtraShiftRes> getExtraShiftRequests(Long employeeId);
+
+  ExtraShiftRes getExtraShiftRequestsByDate(Long employeeId, LocalDate date);
 }

--- a/src/main/java/com/stamp/api/extraShift/service/ReadExtraShiftServiceImpl.java
+++ b/src/main/java/com/stamp/api/extraShift/service/ReadExtraShiftServiceImpl.java
@@ -1,7 +1,11 @@
 package com.stamp.api.extraShift.service;
 
 import com.stamp.api.extraShift.dto.response.ExtraShiftRes;
+import com.stamp.api.extraShift.entity.ExtraShift;
+import com.stamp.api.extraShift.exception.ExtraShiftErrorCode;
 import com.stamp.api.extraShift.repository.ExtraShiftRepository;
+import com.stamp.global.exception.DomainException;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,5 +21,20 @@ public class ReadExtraShiftServiceImpl implements ReadExtraShiftService {
     return extraShiftRepository.findAllByEmployeeId(employeeId).stream()
         .map(ExtraShiftRes::of)
         .toList();
+  }
+
+  @Override
+  public ExtraShiftRes getExtraShiftRequestsByDate(Long employeeId, LocalDate date) {
+    return ExtraShiftRes.of(findExtraShiftWithDate(employeeId, date));
+  }
+
+  private ExtraShift findExtraShiftWithDate(Long employeeId, LocalDate date) {
+    return extraShiftRepository
+        .findByEmployeeIdAndRequestDate(employeeId, date)
+        .orElseThrow(
+            () ->
+                new DomainException(
+                    ExtraShiftErrorCode.EXTRA_SHIFT_NOT_FOUND,
+                    "ExtraShiftServiceImpl.getExtraShiftRequestsByDate"));
   }
 }


### PR DESCRIPTION

<!-- 제목은 `[#이슈번호] 제목`으로 작성해주세요. (ex) [#1] 프로젝트 초기 설정 작업 -->

### 🧑‍💻 작업 내용

- 특정 직원의 특정 날짜에 요청된 추가 근무에 대한 조회 로직을 추가했습니다.
- 추가 근무의 생성 상태를 추가했습니다.(요청 시점에 바로 요청 상태로 변경됨)

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #90 
